### PR TITLE
fix: send info logging to stderr

### DIFF
--- a/libexec/helpers
+++ b/libexec/helpers
@@ -10,7 +10,7 @@ function warn_and_continue() {
 }
 
 function info() {
-  echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
+  echo -e "\033[0;32m[INFO] ${1}\033[0;39m" >&2
 }
 
 # Curl wrapper to switch TLS option for each OS

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -29,17 +29,17 @@ v=$(tgenv list-remote | head -n 1)
 echo "### Install latest version with Regex"
 cleanup || error_and_die "Cleanup failed?!"
 
-v=$(tgenv list-remote | grep 0.11.1 | head -n 1)
+v=$(tgenv list-remote | grep 0.22.5 | head -n 1)
 (
-  tgenv install latest:^0.11 || exit 1
-  tgenv use latest:^0.11 || exit 1
+  tgenv install latest:^0.22 || exit 1
+  tgenv use latest:^0.22 || exit 1
   check_version ${v} || exit 1
 ) || error_and_proceed "Installing latest version ${v} with Regex"
 
 echo "### Install specific version"
 cleanup || error_and_die "Cleanup failed?!"
 
-v=0.9.9
+v=0.23.10
 (
   tgenv install ${v} || exit 1
   tgenv use ${v} || exit 1
@@ -49,7 +49,7 @@ v=0.9.9
 echo "### Install specific .terragrunt-version"
 cleanup || error_and_die "Cleanup failed?!"
 
-v=0.12.3
+v=0.22.2
 echo ${v} > ./.terragrunt-version
 (
   tgenv install || exit 1
@@ -59,8 +59,8 @@ echo ${v} > ./.terragrunt-version
 echo "### Install latest:<regex> .terragrunt-version"
 cleanup || error_and_die "Cleanup failed?!"
 
-v=$(tgenv list-remote | grep -e '^0.9' | head -n 1)
-echo "latest:^0.9" > ./.terragrunt-version
+v=$(tgenv list-remote | grep -e '^0.22' | head -n 1)
+echo "latest:^0.22" > ./.terragrunt-version
 (
   tgenv install || exit 1
   check_version ${v} || exit 1

--- a/test/test_list.sh
+++ b/test/test_list.sh
@@ -19,17 +19,16 @@ source $(dirname $0)/helpers.sh \
 echo "### List local versions"
 cleanup || error_and_die "Cleanup failed?!"
 
-for v in 0.12.15 0.12.9 0.11.1 0.10.0 0.9.3; do
+for v in 0.23.13 0.23.10 0.22.5 0.22.2; do
   tgenv install ${v} || error_and_proceed "Install of version ${v} failed"
 done
 
 result=$(tgenv list)
 expected="$(cat << EOS
-0.12.15
-0.12.9
-0.11.1
-0.10.0
-0.9.3
+  0.23.13
+  0.23.10
+  0.22.5
+* 0.22.2 (set by $(tgenv version-file))
 EOS
 )"
 

--- a/test/test_symlink.sh
+++ b/test/test_symlink.sh
@@ -23,9 +23,9 @@ export PATH="${TGENV_BIN_DIR}:${PATH}"
 
 echo "### Test supporting symlink"
 cleanup || error_and_die "Cleanup failed?!"
-tgenv install 0.12.15 || error_and_proceed "Install failed"
-tgenv use 0.12.15 || error_and_proceed "Use failed"
-check_version 0.12.15 || error_and_proceed "Version check failed"
+tgenv install 0.23.13 || error_and_proceed "Install failed"
+tgenv use 0.23.13 || error_and_proceed "Use failed"
+check_version 0.23.13 || error_and_proceed "Version check failed"
 
 if [ ${#errors[@]} -gt 0 ]; then
   echo -e "\033[0;31m===== The following symlink tests failed =====\033[0;39m" >&2

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -19,11 +19,11 @@ source $(dirname $0)/helpers.sh \
 echo "### Uninstall local versions"
 cleanup || error_and_die "Cleanup failed?!"
 
-v=0.9.9
+v=0.22.2
 (
   tgenv install ${v} || exit 1
   tgenv uninstall ${v} || exit 1
-  tgenv list | grep 0.9.9 && exit 1 || exit 0
+  tgenv list | grep 0.22.2 && exit 1 || exit 0
 ) || error_and_proceed "Uninstall of version ${v} failed"
 
 echo "### Uninstall latest version"
@@ -39,10 +39,10 @@ v=$(tgenv list-remote | head -n 1)
 echo "### Uninstall latest version with Regex"
 cleanup || error_and_die "Cleanup failed?!"
 
-v=$(tgenv list-remote | grep 0.12.15 | head -n 1)
+v=$(tgenv list-remote | grep 0.22.5 | head -n 1)
 (
-  tgenv install latest:^0.12 || exit 1
-  tgenv uninstall latest:^0.12 || exit 1
+  tgenv install latest:^0.22 || exit 1
+  tgenv uninstall latest:^0.22 || exit 1
   tgenv list | grep ${v} && exit 1 || exit 0
 ) || error_and_proceed "Uninstalling latest version ${v} with Regex"
 


### PR DESCRIPTION
All output from Terragrunt related tooling should go to stderr. See issue #11 for more detail.

Fixes: #11 