### PR TITLE
Use debug logging

### DIFF
--- a/libexec/helpers
+++ b/libexec/helpers
@@ -9,6 +9,14 @@ function warn_and_continue() {
   echo -e "tgenv: $(basename ${0}): \033[0;33m[WARN] ${1}\033[0;39m" >&2
 }
 
+function debug() {
+  if [ -z "${TGENV_DEBUG}" ]; then
+    return
+  fi
+
+  echo -e "\033[0;34m[DEBUG] ${1}\033[0;39m"
+}
+
 function info() {
   echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
 }

--- a/libexec/tgenv-exec
+++ b/libexec/tgenv-exec
@@ -17,9 +17,9 @@ set -e
 [ -n "${TGENV_DEBUG}" ] && set -x
 source "${TGENV_ROOT}/libexec/helpers"
 
-info 'Getting version from tgenv-version-name';
+debug 'Getting version from tgenv-version-name';
 TGENV_VERSION="$(tgenv-version-name)" \
-  && info "TGENV_VERSION is ${TGENV_VERSION}" \
+  && debug "TGENV_VERSION is ${TGENV_VERSION}" \
   || {
     # Errors will be logged from tgenv-version name,
     # we don't need to trouble STDERR with repeat information here


### PR DESCRIPTION
Switch to debug logging similar to `tfenv`. Having info output each time
`terragrunt` is run can be problematic.