### PR TITLE
Added so you can override version_url with environment variable tgenv…

### DIFF
--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -56,7 +56,11 @@ case "$(uname -s)" in
     ;;
 esac
 
-version_url="https://github.com/gruntwork-io/terragrunt/releases/download/v${version}"
+if [ -z ${tgenv_version_url} ]; then
+    version_url="https://github.com/gruntwork-io/terragrunt/releases/download/v${version}"
+else
+    version_url="${tgenv_version_url}/v${version}"
+fi
 
 tarball_name="terragrunt_${os}";
 


### PR DESCRIPTION
…_version_url, with this fix you can specify another mirror to fetch terragrunt binary from.