### PR TITLE
Fixed support for automatically installing terragrunt 

### DIFF
--- a/lib/bashlog.sh
+++ b/lib/bashlog.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+set -uo pipefail;
+
+function _log_exception() {
+  (
+    BASHLOG_FILE=0;
+    BASHLOG_JSON=0;
+    BASHLOG_SYSLOG=0;
+
+    log 'error' "Logging Exception: $*";
+  );
+};
+export -f _log_exception;
+
+function log() {
+  local date_format="${BASHLOG_DATE_FORMAT:-+%F %T}";
+  local date="$(date "${date_format}")";
+  local date_s="$(date "+%s")";
+
+  local file="${BASHLOG_FILE:-0}";
+  local file_path="${BASHLOG_FILE_PATH:-/tmp/$(basename "${0}").log}";
+
+  local json="${BASHLOG_JSON:-0}";
+  local json_path="${BASHLOG_JSON_PATH:-/tmp/$(basename "${0}").log.json}";
+
+  local syslog="${BASHLOG_SYSLOG:-0}";
+  local tag="${BASHLOG_SYSLOG_TAG:-$(basename "${0}")}";
+  local facility="${BASHLOG_SYSLOG_FACILITY:-local0}";
+  local pid="${$}";
+
+  local level="${1}";
+  local upper="$(echo "${level}" | awk '{print toupper($0)}')";
+  local debug_level="${TGENV_DEBUG:-0}";
+  local stdout_colours="${BASHLOG_COLOURS:-1}";
+  local stdout_extra="${BASHLOG_EXTRA:-0}";
+
+  local custom_eval_prefix="${BASHLOG_I_PROMISE_TO_BE_CAREFUL_CUSTOM_EVAL_PREFIX:-""}";
+
+  shift 1;
+
+  local line="$@";
+
+  # RFC 5424
+  #
+  # Numerical         Severity
+  #   Code
+  #
+  #    0       Emergency: system is unusable
+  #    1       Alert: action must be taken immediately
+  #    2       Critical: critical conditions
+  #    3       Error: error conditions
+  #    4       Warning: warning conditions
+  #    5       Notice: normal but significant condition
+  #    6       Informational: informational messages
+  #    7       Debug: debug-level messages
+
+  local severities_DEBUG=7;
+  local severities_INFO=6;
+  local severities_NOTICE=5; # Unused
+  local severities_WARN=4;
+  local severities_ERROR=3;
+  local severities_CRIT=2;   # Unused
+  local severities_ALERT=1;  # Unused
+  local severities_EMERG=0;  # Unused
+
+  local severity_var="severities_${upper}"
+  local severity="${!severity_var:-3}"
+
+  if [ "${debug_level}" -gt 0 ] || [ "${severity}" -lt 7 ]; then
+
+    if [ "${syslog}" -eq 1 ]; then
+      local syslog_line="${upper}: ${line}";
+
+      logger \
+        --id="${pid}" \
+        -t "${tag}" \
+        -p "${facility}.${severity}" \
+        "${syslog_line}" \
+        || _log_exception "logger --id=\"${pid}\" -t \"${tag}\" -p \"${facility}.${severity}\" \"${syslog_line}\"";
+    fi;
+
+    if [ "${file}" -eq 1 ]; then
+      local file_line="${date} [${upper}] ${line}";
+
+      if [ -n "${custom_eval_prefix}" ]; then
+        file_line="$(eval "${custom_eval_prefix}")${file_line}";
+      fi;
+
+      echo -e "${file_line}" >> "${file_path}" \
+        || _log_exception "echo -e \"${file_line}\" >> \"${file_path}\"";
+    fi;
+
+    if [ "${json}" -eq 1 ]; then
+      local json_line="$(printf '{"timestamp":"%s","level":"%s","message":"%s"}' "${date_s}" "${level}" "${line}")";
+      echo -e "${json_line}" >> "${json_path}" \
+        || _log_exception "echo -e \"${json_line}\" >> \"${json_path}\"";
+    fi;
+
+  fi;
+
+  local colours_DEBUG='\033[34m'  # Blue
+  local colours_INFO='\033[32m'   # Green
+  local colours_NOTICE=''         # Unused
+  local colours_WARN='\033[33m'   # Yellow
+  local colours_ERROR='\033[31m'  # Red
+  local colours_CRIT=''           # Unused
+  local colours_ALERT=''          # Unused
+  local colours_EMERG=''          # Unused
+  local colours_DEFAULT='\033[0m' # Default
+
+  local norm="${colours_DEFAULT}";
+  local colour_var="colours_${upper}"
+  local colour="${!colour_var:-\033[31m}";
+
+  local std_line;
+  if [ "${debug_level}" -le 1 ]; then
+    std_line="${line}";
+  elif [ "${debug_level}" -ge 2 ]; then
+    std_line="${0}: ${line}";
+  fi;
+
+  if [ "${stdout_extra}" -eq 1 ]; then
+    std_line="${date} [${upper}] ${std_line}";
+  fi;
+
+  if [ -n "${custom_eval_prefix}" ]; then
+    std_line="$(eval "${custom_eval_prefix}")${std_line}";
+  fi;
+
+  if [ "${stdout_colours}" -eq 1 ]; then
+    std_line="${colour}${std_line}${norm}";
+  fi;
+
+  # Standard Output (Pretty)
+  case "${level}" in
+    'info'|'warn')
+      echo -e "${std_line}";
+      ;;
+    'debug')
+      if [ "${debug_level}" -gt 0 ]; then
+        # We are debugging to STDERR on purpose
+        # tgenv relies on STDOUT between libexecs to function
+        echo -e "${std_line}" >&2;
+      fi;
+      ;;
+    'error')
+      echo -e "${std_line}" >&2;
+      if [ "${debug_level}" -gt 1 ]; then
+        echo -e "Here's a shell for debugging the current environment. 'exit 0' to resume script from here. Non-zero exit code will abort - parent shell will terminate." >&2;
+        bash || exit "${?}";
+      else
+        exit 1;
+      fi;
+      ;;
+    *)
+      log 'error' "Undefined log level trying to log: $*";
+      ;;
+  esac
+};
+export -f log;
+
+declare prev_cmd="null";
+declare this_cmd="null";
+trap 'prev_cmd=$this_cmd; this_cmd=$BASH_COMMAND' DEBUG \
+  && log debug 'DEBUG trap set' \
+  || log 'error' 'DEBUG trap failed to set';
+
+# This is an option if you want to log every single command executed,
+# but it will significantly impact script performance and unit tests will fail
+
+#trap 'prev_cmd=$this_cmd; this_cmd=$BASH_COMMAND; log debug $this_cmd' DEBUG \
+#  && log debug 'DEBUG trap set' \
+#  || log 'error' 'DEBUG trap failed to set';

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+set -uo pipefail;
+
+if [ -z "${TGENV_ROOT:-""}" ]; then
+  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+  readlink_f() {
+    local target_file="${1}";
+    local file_name;
+
+    while [ "${target_file}" != "" ]; do
+      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TGENV_ROOT";
+      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TGENV_ROOT";
+      target_file="$(readlink "${file_name}")";
+    done;
+
+    echo "$(pwd -P)/${file_name}";
+  };
+
+  TGENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
+  [ -n ${TGENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TGENV_ROOT";
+else
+  TGENV_ROOT="${TGENV_ROOT%/}";
+fi;
+export TGENV_ROOT;
+
+if [ -z "${TGENV_CONFIG_DIR:-""}" ]; then
+  TGENV_CONFIG_DIR="$TGENV_ROOT";
+else
+  TGENV_CONFIG_DIR="${TGENV_CONFIG_DIR%/}";
+fi
+export TGENV_CONFIG_DIR;
+
+if [ "${TGENV_DEBUG:-0}" -gt 0 ]; then
+  # Only reset DEBUG if TGENV_DEBUG is set, and DEBUG is unset or already a number
+  if [[ "${DEBUG:-0}" =~ ^[0-9]+$ ]] && [ "${DEBUG:-0}" -gt "${TGENV_DEBUG:-0}" ]; then
+    export DEBUG="${TGENV_DEBUG:-0}";
+  fi;
+  if [[ "${TGENV_DEBUG}" -gt 2 ]]; then
+    export PS4='+ [${BASH_SOURCE##*/}:${LINENO}] ';
+    set -x;
+  fi;
+fi;
+
+source "${TGENV_ROOT}/lib/bashlog.sh";
+
+resolve_version () {
+  declare version_requested version regex min_required version_file;
+
+  declare arg="${1:-""}";
+
+  if [ -z "${arg}" -a -z "${TGENV_TERRAGRUNT_VERSION:-""}" ]; then
+    version_file="$(tfenv-version-file)";
+    log 'debug' "Version File: ${version_file}";
+
+    if [ "${version_file}" != "${TGENV_CONFIG_DIR}/version" ]; then
+      log 'debug' "Version File (${version_file}) is not the default \${TGENV_CONFIG_DIR}/version (${TGENV_CONFIG_DIR}/version)";
+      version_requested="$(cat "${version_file}")" \
+        || log 'error' "Failed to open ${version_file}";
+
+    elif [ -f "${version_file}" ]; then
+      log 'debug' "Version File is the default \${TGENV_CONFIG_DIR}/version (${TGENV_CONFIG_DIR}/version)";
+      version_requested="$(cat "${version_file}")" \
+        || log 'error' "Failed to open ${version_file}";
+
+      # Absolute fallback
+      if [ -z "${version_requested}" ]; then
+        log 'debug' 'Version file had no content. Falling back to "latest"';
+        version_requested='latest';
+      fi;
+
+    else
+      log 'debug' "Version File is the default \${TGENV_CONFIG_DIR}/version (${TGENV_CONFIG_DIR}/version) but it doesn't exist";
+      log 'info' 'No version requested on the command line or in the version file search path. Installing "latest"';
+      version_requested='latest';
+    fi;
+  elif [ -n "${TGENV_TERRAGRUNT_VERSION:-""}" ]; then
+    version_requested="${TGENV_TERRAGRUNT_VERSION}";
+    log 'debug' "TGENV_TERRAGRUNT_VERSION is set: ${TGENV_TERRAGRUNT_VERSION}";
+  else
+    version_requested="${arg}";
+  fi;
+
+  log 'debug' "Version Requested: ${version_requested}";
+
+  if [[ "${version_requested}" =~ ^latest\:.*$ ]]; then
+    version="${version_requested%%\:*}";
+    regex="${version_requested##*\:}";
+    log 'debug' "Version uses latest keyword with regex: ${regex}";
+  elif [[ "${version_requested}" =~ ^latest$ ]]; then
+    version="${version_requested}";
+    regex="^[0-9]\+\.[0-9]\+\.[0-9]\+$";
+    log 'debug' "Version uses latest keyword alone. Forcing regex to match stable versions only: ${regex}";
+  else
+    version="${version_requested}";
+    regex="^${version_requested}$";
+    log 'debug' "Version is explicit: ${version}. Regex enforces the version: ${regex}";
+  fi;
+}
+
+# Curl wrapper to switch TLS option for each OS
+function curlw () {
+  local TLS_OPT="--tlsv1.2";
+
+  # Check if curl is 10.12.6 or above
+  if [[ -n "$(command -v sw_vers 2>/dev/null)" && ("$(sw_vers)" =~ 10\.12\.([6-9]|[0-9]{2}) || "$(sw_vers)" =~ 10\.1[3-9]) ]]; then
+    TLS_OPT="";
+  fi;
+
+  curl ${TLS_OPT} "$@";
+}
+export -f curlw;
+
+check_active_version() {
+  local v="${1}";
+  [ -n "$(${TGENV_ROOT}/bin/terragrunt version | grep -E "^Terragrunt v${v}((-dev)|( \([a-f0-9]+\)))?$")" ];
+}
+export -f check_active_version;
+
+check_installed_version() {
+  local v="${1}";
+  local bin="${TGENV_CONFIG_DIR}/versions/${v}/terragrunt";
+  [ -n "$(${bin} version | grep -E "^Terragrunt v${v}((-dev)|( \([a-f0-9]+\)))?$")" ];
+};
+export -f check_installed_version;
+
+check_default_version() {
+  local v="${1}";
+  local def="$(cat "${TGENV_CONFIG_DIR}/version")";
+  [ "${def}" == "${v}" ];
+};
+export -f check_default_version;
+
+cleanup() {
+  log 'info' 'Performing cleanup';
+  local pwd="$(pwd)";
+  log 'debug' "Deleting ${pwd}/versions";
+  rm -rf ./versions;
+  log 'debug' "Deleting ${pwd}/.terragrunt-version";
+  rm -rf ./.terragrunt-version;
+  log 'debug' "Deleting ${pwd}/min_required.tf";
+  rm -rf ./min_required.tf;
+};
+export -f cleanup;
+
+function error_and_proceed() {
+  errors+=("${1}");
+  log 'warn' "Test Failed: ${1}";
+};
+export -f error_and_proceed;
+
+export TGENV_HELPERS=1;

--- a/libexec/tgenv-exec
+++ b/libexec/tgenv-exec
@@ -17,6 +17,17 @@ set -e
 [ -n "${TGENV_DEBUG}" ] && set -x
 source "${TGENV_ROOT}/libexec/helpers"
 
+if [ -n "${TGENV_HELPERS:-""}" ]; then
+  log 'debug' 'TGENV_HELPERS is set, not sourcing helpers again';
+else
+  [ "${TGENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  if source "${TGENV_ROOT}/lib/helpers.sh"; then
+    log 'debug' 'Helpers sourced successfully';
+  else
+    early_death "Failed to source helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  fi;
+fi;
+
 info 'Getting version from tgenv-version-name';
 TGENV_VERSION="$(tgenv-version-name)" \
   && info "TGENV_VERSION is ${TGENV_VERSION}" \
@@ -27,7 +38,7 @@ TGENV_VERSION="$(tgenv-version-name)" \
   };
 export TGENV_VERSION;
 
-if [ ! -d "${TGENV_ROOT}/versions/${TGENV_VERSION}" ]; then
+if [ ! -d "${TGENV_CONFIG_DIR}/versions/${TGENV_VERSION}" ]; then
   if [ "${TGENV_AUTO_INSTALL:-false}" == "true" ]; then
     info "version '${TGENV_VERSION}' is not installed (set by $(tgenv-version-file)). Installing now as TGENV_AUTO_INSTALL==true";
     tgenv-install;
@@ -36,6 +47,6 @@ if [ ! -d "${TGENV_ROOT}/versions/${TGENV_VERSION}" ]; then
   fi;
 fi;
 
-TG_BIN_PATH="${TGENV_ROOT}/versions/${TGENV_VERSION}/terragrunt"
+TG_BIN_PATH="${TGENV_CONFIG_DIR}/versions/${TGENV_VERSION}/terragrunt"
 export PATH="${TG_BIN_PATH}:${PATH}"
 "${TG_BIN_PATH}" "${@}"

--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -3,11 +3,22 @@
 [ -n "${TGENV_DEBUG}" ] && set -x
 source "${TGENV_ROOT}/libexec/helpers"
 
+if [ -n "${TGENV_HELPERS:-""}" ]; then
+  log 'debug' 'TGENV_HELPERS is set, not sourcing helpers again';
+else
+  [ "${TGENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  if source "${TGENV_ROOT}/lib/helpers.sh"; then
+    log 'debug' 'Helpers sourced successfully';
+  else
+    early_death "Failed to source helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  fi;
+fi;
+
 [ "${#}" -gt 1 ] && error_and_die "usage: tgenv install [<version>]"
 
 declare version_requested version regex
 
-if [ -z "${1}" ]; then
+if [ -z "${1:-""}" ]; then
   version_file="$(tgenv-version-file)"
   if [ "${version_file}" != "${TGENV_ROOT}/version" ]; then
     version_requested="$(cat "${version_file}" || true)"
@@ -31,7 +42,7 @@ fi
 version="$(tgenv-list-remote | grep -e "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in remote"
 
-dst_path="${TGENV_ROOT}/versions/${version}"
+dst_path="${TGENV_CONFIG_DIR}/versions/${version}"
 if [ -f "${dst_path}/terragrunt" ]; then
   echo "Terragrunt v${version} is already installed"
   exit 0

--- a/libexec/tgenv-list
+++ b/libexec/tgenv-list
@@ -3,13 +3,24 @@
 [ -n "${TGENV_DEBUG}" ] && set -x
 source "${TGENV_ROOT}/libexec/helpers"
 
+if [ -n "${TGENV_HELPERS:-""}" ]; then
+  log 'debug' 'TGENV_HELPERS is set, not sourcing helpers again';
+else
+  [ "${TGENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  if source "${TGENV_ROOT}/lib/helpers.sh"; then
+    log 'debug' 'Helpers sourced successfully';
+  else
+    early_death "Failed to source helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  fi;
+fi;
+
 [ "${#}" -ne 0 ] \
   && error_and_die "usage: tgenv list"
 
-[ -d "${TGENV_ROOT}/versions" ] \
+[ -d "${TGENV_CONFIG_DIR}/versions" ] \
   || error_and_die "No versions available. Please install one with: tgenv install"
 
-[[ -x "${TGENV_ROOT}/versions" && -r "${TGENV_ROOT}/versions" ]] \
+[[ -x "${TGENV_CONFIG_DIR}/versions" && -r "${TGENV_CONFIG_DIR}/versions" ]] \
   || error_and_die "tgenv versions directory is inaccessible!"
 
 print_version () {
@@ -20,6 +31,6 @@ print_version () {
     fi
 }
 
-for local_version in $(ls -1 "${TGENV_ROOT}/versions" | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3); do
+for local_version in $(ls -1 "${TGENV_CONFIG_DIR}/versions" | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3); do
     print_version "${local_version}"
 done

--- a/libexec/tgenv-uninstall
+++ b/libexec/tgenv-uninstall
@@ -1,15 +1,28 @@
 #!/usr/bin/env bash
 
 [ -n "${TGENV_DEBUG}" ] && set -x
+
+if [ -n "${TGENV_HELPERS:-""}" ]; then
+  log 'debug' 'TGENV_HELPERS is set, not sourcing helpers again';
+else
+  [ "${TGENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  if source "${TGENV_ROOT}/lib/helpers.sh"; then
+    log 'debug' 'Helpers sourced successfully';
+  else
+    early_death "Failed to source helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  fi;
+fi;
+
+
 source "${TGENV_ROOT}/libexec/helpers"
 
 [ "${#}" -gt 1 ] && error_and_die "usage: tgenv uninstall [<version>]"
 
 declare version_requested version regex
 
-if [ -z "${1}" ]; then
+if [ -z "${1:-""}" ]; then
   version_file="$(tgenv-version-file)"
-  if [ "${version_file}" != "${TGENV_ROOT}/version" ];then
+  if [ "${version_file}" != "${TGENV_CONFIG_DIR}/version" ];then
     version_requested="$(cat "${version_file}" || true)"
   fi
 else
@@ -31,7 +44,7 @@ fi
 version="$(tgenv-list | sed -E 's/^(\*| )? //g; s/ \(set by .+\)$//' | grep -e "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in local"
 
-dst_path="${TGENV_ROOT}/versions/${version}"
+dst_path="${TGENV_CONFIG_DIR}/versions/${version}"
 if [ -f "${dst_path}/terragrunt" ]; then 
   info "Uninstall Terragrunt v${version}"
   rm -r "${dst_path}"

--- a/libexec/tgenv-use
+++ b/libexec/tgenv-use
@@ -3,6 +3,17 @@
 [ -n "${TGENV_DEBUG}" ] && set -x
 source "${TGENV_ROOT}/libexec/helpers"
 
+if [ -n "${TGENV_HELPERS:-""}" ]; then
+  log 'debug' 'TGENV_HELPERS is set, not sourcing helpers again';
+else
+  [ "${TGENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  if source "${TGENV_ROOT}/lib/helpers.sh"; then
+    log 'debug' 'Helpers sourced successfully';
+  else
+    early_death "Failed to source helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  fi;
+fi;
+
 [ "${#}" -ne 1 ] && error_and_die "usage: tgenv use <version>"
 
 declare version_requested version regex
@@ -20,10 +31,10 @@ else
   regex="^${version_requested}$"
 fi
 
-[ -d "${TGENV_ROOT}/versions" ] \
+[ -d "${TGENV_CONFIG_DIR}/versions" ] \
   || error_and_die "No versions of terragrunt installed. Please install one with: tgenv install"
 
-version="$(\ls "${TGENV_ROOT}/versions" \
+version="$(\ls "${TGENV_CONFIG_DIR}/versions" \
   | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
   | grep -e "${regex}" \
   | head -n 1
@@ -31,7 +42,7 @@ version="$(\ls "${TGENV_ROOT}/versions" \
 
 [ -n "${version}" ] || error_and_die "No installed versions of terragrunt matched '${1}'"
 
-target_path="${TGENV_ROOT}/versions/${version}"
+target_path="${TGENV_CONFIG_DIR}/versions/${version}"
 [ -f "${target_path}/terragrunt" ] \
   || error_and_die "Version directory for ${version} is present, but the terragrunt binary is not! Manual intervention required."
 [ -x "${target_path}/terragrunt" ] \

--- a/libexec/tgenv-version-file
+++ b/libexec/tgenv-version-file
@@ -4,6 +4,17 @@
 set -e
 [ -n "${TGENV_DEBUG}" ] && set -x
 
+if [ -n "${TGENV_HELPERS:-""}" ]; then
+  log 'debug' 'TGENV_HELPERS is set, not sourcing helpers again';
+else
+  [ "${TGENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  if source "${TGENV_ROOT}/lib/helpers.sh"; then
+    log 'debug' 'Helpers sourced successfully';
+  else
+    early_death "Failed to source helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  fi;
+fi;
+
 find_local_version_file() {
   local root="${1}"
   while ! [[ "${root}" =~ ^//[^/]*$ ]]; do
@@ -17,4 +28,4 @@ find_local_version_file() {
   return 1
 }
 
-find_local_version_file "${TGENV_DIR}" || find_local_version_file "${HOME}" || echo "${TGENV_ROOT}/version"
+find_local_version_file "${TGENV_DIR}" || find_local_version_file "${HOME}" || echo "${TGENV_CONFIG_DIR}/version"

--- a/libexec/tgenv-version-name
+++ b/libexec/tgenv-version-name
@@ -1,37 +1,140 @@
 #!/usr/bin/env bash
-# Summary: Show the current Terragrunt version
-set -e
+# Summary: Show the currently-selected terragrunt version
 
-[ -n "${TGENV_DEBUG}" ] && set -x
-source "${TGENV_ROOT}/libexec/helpers"
+set -uo pipefail;
 
-[ -d "${TGENV_ROOT}/versions" ] \
-  || error_and_die "No versions of terragrunt installed. Please install one with: tgenv install"
+####################################
+# Ensure we can execute standalone #
+####################################
 
-TGENV_VERSION_FILE="$(tgenv-version-file)"
-TGENV_VERSION="$(cat "${TGENV_VERSION_FILE}" || true)"
+function early_death() {
+  echo "[FATAL] ${0}: ${1}" >&2;
+  exit 1;
+};
+
+if [ -z "${TGENV_ROOT:-""}" ]; then
+  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+  readlink_f() {
+    local target_file="${1}";
+    local file_name;
+
+    while [ "${target_file}" != "" ]; do
+      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TGENV_ROOT";
+      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TGENV_ROOT";
+      target_file="$(readlink "${file_name}")";
+    done;
+
+    echo "$(pwd -P)/${file_name}";
+  };
+
+  TGENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
+  [ -n "${TGENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TGENV_ROOT";
+else
+  TGENV_ROOT="${TGENV_ROOT%/}";
+fi;
+export TGENV_ROOT;
+
+if [ -n "${TGENV_HELPERS:-""}" ]; then
+  log 'debug' 'TGENV_HELPERS is set, not sourcing helpers again';
+else
+  [ "${TGENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  if source "${TGENV_ROOT}/lib/helpers.sh"; then
+    log 'debug' 'Helpers sourced successfully';
+  else
+    early_death "Failed to source helpers from ${TGENV_ROOT}/lib/helpers.sh";
+  fi;
+fi;
+
+# Ensure libexec and bin are in $PATH
+for dir in libexec bin; do
+  case ":${PATH}:" in
+    *:${TGENV_ROOT}/${dir}:*) log 'debug' "\$PATH already contains '${TGENV_ROOT}/${dir}', not adding it again";;
+    *)
+      log 'debug' "\$PATH does not contain '${TGENV_ROOT}/${dir}', prepending and exporting it now";
+      export PATH="${TGENV_ROOT}/${dir}:${PATH}";
+      ;;
+  esac;
+done;
+
+#####################
+# Begin Script Body #
+#####################
+
+if [[ -z "${TGENV_TERRAGRUNT_VERSION:-""}" ]]; then
+  TGENV_VERSION_FILE="$(tgenv-version-file)" \
+    && log 'debug' "TGENV_VERSION_FILE retrieved from tgenv-version-file: ${TGENV_VERSION_FILE}" \
+    || log 'error' 'Failed to retrieve TGENV_VERSION_FILE from tgenv-version-file';
+
+  TGENV_VERSION="$(cat "${TGENV_VERSION_FILE}" || true)" \
+    && log 'debug' "TGENV_VERSION specified in TGENV_VERSION_FILE: ${TGENV_VERSION}";
+
+  TGENV_VERSION_SOURCE="${TGENV_VERSION_FILE}";
+else
+  TGENV_VERSION="${TGENV_TERRAGRUNT_VERSION}" \
+    && log 'debug' "TGENV_VERSION specified in TGENV_TERRAGRUNT_VERSION: ${TGENV_VERSION}";
+
+  TGENV_VERSION_SOURCE='TGENV_TERRAGRUNT_VERSION';
+fi;
 
 if [[ "${TGENV_VERSION}" =~ ^latest.*$ ]]; then
-  [[ "${TGENV_VERSION}" =~ ^latest\:.*$ ]] && regex="${TGENV_VERSION##*\:}"
-  version="$(\ls "${TGENV_ROOT}/versions" \
-    | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
-    | grep -e "${regex}" \
-    | head -n 1
-  )"
-  [ -n "${version}" ] || error_and_die "No installed versions of terragrunt matched '${TGENV_VERSION}'"
-  TGENV_VERSION="${version}"
-fi
+  log 'debug' "TGENV_VERSION uses 'latest' keyword: ${TGENV_VERSION}";
 
-[ -z "${TGENV_VERSION}" ] \
-  && error_and_die "Version could not be resolved (set by ${TGENV_VERSION_FILE} or tgenv use <version>)"
+  [ -d "${TGENV_CONFIG_DIR}/versions" ] \
+    || log 'error' 'No versions of terragrunt installed. Please install one with: tgenv install';
 
-version_exists() {
-  local version="${1}"
-  [ -d "${TGENV_ROOT}/versions/${version}" ]
-}
+  if [[ "${TGENV_VERSION}" =~ ^latest\:.*$ ]]; then
+    regex="${TGENV_VERSION##*\:}";
+    log 'debug' "'latest' keyword uses regex: ${regex}";
+  else
+    regex="^[0-9]\+\.[0-9]\+\.[0-9]\+$";
+    log 'debug' "Version uses latest keyword alone. Forcing regex to match stable versions only: ${regex}";
+  fi;
 
-if ! version_exists "${TGENV_VERSION}"; then
-  warn_and_continue "version '${TGENV_VERSION}' is not installed (set by ${TGENV_VERSION_FILE})"
-fi
+  declare local_version='';
+  if [[ -d "${TGENV_CONFIG_DIR}/versions" ]]; then
+    local_version="$(\find "${TGENV_CONFIG_DIR}/versions/" -type d -exec basename {} \; \
+      | tail -n +2 \
+      | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
+      | grep -e "${regex}" \
+      | head -n 1)";
+  fi;
 
-echo "${TGENV_VERSION}"
+  if [[ "${TGENV_AUTO_INSTALL:-true}" == "true" ]]; then
+    log 'debug' "Trying to find the remote version using the regex: ${regex}";
+    remote_version="$(tgenv-list-remote | grep -e "${regex}" | head -n 1)";
+    if [[ -n "${remote_version}" ]]; then
+        if [[ "${local_version}" != "${remote_version}" ]]; then
+          log 'debug' "The installed version '${local_version}' does not much the remote version '${remote_version}'";
+          TGENV_VERSION="${remote_version}";
+        else
+          TGENV_VERSION="${local_version}";
+        fi;
+    else
+      log 'error' "No versions matching '${requested}' found in remote";
+    fi;
+  else
+    if [[ -n "${local_version}" ]]; then
+      TGENV_VERSION="${local_version}";
+    else
+      log 'error' "No installed versions of terragrunt matched '${TGENV_VERSION}'";
+    fi;
+  fi;
+else
+  log 'debug' 'TGENV_VERSION does not use "latest" keyword';
+
+  # Accept a v-prefixed version, but strip the v.
+  if [[ "${TGENV_VERSION}" =~ ^v.*$ ]]; then
+    log 'debug' "Version Requested is prefixed with a v. Stripping the v."
+    TGENV_VERSION="${TGENV_VERSION#v*}";
+  fi;
+fi;
+
+if [[ -z "${TGENV_VERSION}" ]]; then
+  log 'error' "Version could not be resolved (set by ${TGENV_VERSION_SOURCE} or tgenv use <version>)";
+fi;
+
+if [[ ! -d "${TGENV_CONFIG_DIR}/versions/${TGENV_VERSION}" ]]; then
+  log 'debug' "version '${TGENV_VERSION}' is not installed (set by ${TGENV_VERSION_SOURCE})";
+fi;
+
+echo "${TGENV_VERSION}";


### PR DESCRIPTION
The current implementation of `tgenv-version-name` errors out if the version specified isn't already downloaded and installed.

I pulled these changes from the latest `tfenv-version-name` file from the tfenv repo: https://github.com/tfutils/tfenv/blob/master/libexec/tfenv-version-name. 

This also adds support for using a `TGENV_CONFIG_DIR` environment variable to install terragrunt versions into a user defined directory. This works just like the `TFENV_CONFIG_DIR` from tfenv and is ported over from their code.

I just switched all references from terraform to terragrunt.

Leaving this here in case anyone else finds it useful.