### PR TITLE
Prevent "info" logs when TGENV_DEBUG is empty or undefined

### DIFF
--- a/libexec/helpers
+++ b/libexec/helpers
@@ -10,6 +10,7 @@ function warn_and_continue() {
 }
 
 function info() {
+  [ -z "${TGENV_DEBUG:-}" ] && return;
   echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
 }
 


### PR DESCRIPTION

#### feat: prevent "info" logs when TGENV_DEBUG is empty or undefined

* Cleaner output on every terragrunt command

#### Fix: Some commands cannot write well formatted outputs to file. 

Due to the following 2 lines on every commands, some terragrunt commands and utilisies fails  

```shell
[INFO] Getting version from tgenv-version-name
[INFO] TGENV_VERSION is 0.38.9
```

* ``terragrunt graph-dependencies > dependencies.dot```
