### PR TITLE
Update tgenv-install - Fix for windows downloads

### DIFF
--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -43,13 +43,13 @@ case "$(uname -s)" in
     os="darwin_${TGENV_ARCH}"
     ;;
   MINGW64*)
-    os="windows_${TGENV_ARCH}"
+    os="windows_${TGENV_ARCH}.exe"
     ;;
   MSYS_NT*)
-    os="windows_${TGENV_ARCH}"
+    os="windows_${TGENV_ARCH}.exe"
     ;;
   CYGWIN_NT*)
-    os="windows_${TGENV_ARCH}"
+    os="windows_${TGENV_ARCH}.exe"
     ;;
   *)
     os="linux_${TGENV_ARCH}"


### PR DESCRIPTION
Fixed issues with missing file extension for windows. Cannot download any windows distributions without the extensions.

See windows distribution URLS from: https://github.com/gruntwork-io/terragrunt/releases/

example of download link:
https://github.com/gruntwork-io/terragrunt/releases/download/v0.38.6/terragrunt_windows_amd64.exe